### PR TITLE
Refactor Banner component

### DIFF
--- a/src/Homepage.tsx
+++ b/src/Homepage.tsx
@@ -9,16 +9,19 @@ export default function Homepage() {
       <div className="flex h-screen w-screen">
         <Banner
           message={
-            'Still in development! Apologies for any device responsive issues!'
-          }
-          url="https://github.com/users/lamnguynn/projects/2/views/1"
-          urlText={
-            <>
+            <p className="text-white">
+              Still in development! Apologies for any device responsive issues!
               Roadmap{' '}
               <span className="underline underline-offset-4 decoration-blue-600 decoration-2">
-                here!
+                <a
+                  href={'https://github.com/users/lamnguynn/projects/2/views/1'}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  here!
+                </a>
               </span>
-            </>
+            </p>
           }
         />
         <Modal />

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,20 +1,13 @@
 import type { ReactNode } from 'react';
 
 interface Props {
-  message: string;
-  url?: string;
-  urlText?: ReactNode;
+  message: ReactNode;
 }
 
-export default function Banner({ message, url, urlText }: Props) {
+export default function Banner({ message }: Props) {
   return (
     <div className="w-full h-fit p-2 bg-red-400 absolute flex justify-center items-center z-[100000000]">
-      <p className="text-white">
-        {message}{' '}
-        <a href={url} target="_blank" rel="noreferrer">
-          {urlText}
-        </a>
-      </p>
+      {message}
     </div>
   );
 }


### PR DESCRIPTION
- Resolve issue where the text `Roadmap here!` had the entire text be a link instead of the highlighted `here!` span.
- Refactored `Banner` to accept one param for the message as a ReactNode